### PR TITLE
Remove (SB-INT:INFO :SETF :INVERSE symbol) calls for SBCL ≥ 1.3.4

### DIFF
--- a/core/src/item/symbol.lisp
+++ b/core/src/item/symbol.lisp
@@ -487,8 +487,7 @@ Note that this only returns standalone (toplevel) generic writers."
 	 (when-let* ((macro (macro-function symbol))
 		     (macro-definition
 		      (make-macro-definition :symbol symbol :function macro)))
-	   (when-let ((expander (or (sb-int:info :setf :inverse symbol)
-				    (sb-int:info :setf :expander symbol))))
+           (when-let ((expander (sb-int:info :setf :expander symbol)))
 	     (let ((expander-definition
 		     (make-setf-expander-definition
 		      :symbol symbol
@@ -529,8 +528,7 @@ Note that this only returns standalone (toplevel) generic writers."
 			    (fdefinition writer-name))))
 		(ordinary-writer-p
 		  (and writer (not (typep writer 'generic-function))))
-		(expander (or (sb-int:info :setf :inverse symbol)
-			      (sb-int:info :setf :expander symbol))))
+                (expander (sb-int:info :setf :expander symbol)))
 	   (cond ((and function (or writer expander))
 		  (let ((accessor-definition (make-accessor-definition
 					      :symbol symbol
@@ -579,8 +577,7 @@ Note that this only returns standalone (toplevel) generic writers."
 		    (when (fboundp writer-name)
 		      (fdefinition writer-name))))
 		(generic-writer-p (typep writer 'generic-function))
-		(expander (or (sb-int:info :setf :inverse symbol)
-			      (sb-int:info :setf :expander symbol))))
+                (expander (sb-int:info :setf :expander symbol)))
 	   (cond ((and function (or writer expander))
 		  (let ((generic-definition
 			  (make-generic-accessor-definition


### PR DESCRIPTION
With
https://github.com/sbcl/sbcl/commit/6066c03a30a50d072f7d6b625ac5b8942a7a9c8d
SBCL no  longer exports (sb-int:info :setf  :inverse symbol) separately;
the “inverse” SetF is found through (sb-int:info :setf :expander symbol)
now  working for  all  types of  SetF definitions.  This  was merged  into
SBCL-1.3.4  https://github.com/sbcl/sbcl/releases/tag/sbcl-1.3.4 (&seq.)
released 31 Mar, 2016.

This was released in Debian (Sid) on 11 Aug, 2016, and Fedora (24) on 30
Aug,  2016. It  seems safe  to omit  these calls,  since (a)  most users
probably will  signal an error  by now,  anyway; and (b)  the worst-case
(SBCL  ≤ 1.3.3)  is losing  some “short  DEFSETF” references  until they
upgrade, which are not terribly common.